### PR TITLE
Update php.md

### DIFF
--- a/php.md
+++ b/php.md
@@ -817,7 +817,7 @@ When the closure only has one expression, prefer the use of arrow functions.
 <?php
 
 // Preferred
-$nums = array_map(fn($n) => $n * $factor, [1, 2, 3, 4]);
+$nums = array_map(fn ($n) => $n * $factor, [1, 2, 3, 4]);
 
 // Not preferred
 $nums = array_map(function($n) {


### PR DESCRIPTION
@iwiznia I noticed this while reading through it. I think that this should also apply to `fn`?

> Closures MUST be declared with a space after the function keyword