### PR TITLE
Updating C++ style guidelines for optionals, early returns, and assertions

### DIFF
--- a/cpp.md
+++ b/cpp.md
@@ -295,9 +295,9 @@ You should prefer using `EXPECT_` over `ASSERT_` in tests, given that when `EXPE
 You should use `ASSERT_` for assertions that need to pass before the next assertions in the test are run. Said differently, if one assertion depends on another one succeeding, you should use `ASSERT_` on the first one because there's no point in continuing to run the test if the `ASSERT_` fails
 
 ```cpp
-// GOOD
-ASSERT_TRUE(true);
+// Good
+ASSERT_TRUE(expression);
 
 // Bad
-EXPECT_TRUE(true);
+EXPECT_TRUE(expression);
 ```

--- a/cpp.md
+++ b/cpp.md
@@ -228,3 +228,17 @@ db.read("SELECT name, value FROM nameValuePairs;", result);
 auto name = result[0]["name"];
 auto value = result[0]["value"];
 ```
+
+## Handling optionals
+
+When unpacking an optional value, you should use the `.value()` method or `.value_or()` rather than directly dereferencing with `*`
+
+```cpp
+const optional<string> myOptional = optional{"Hello world!"};
+
+// Do this
+const string good = myOptional.value();
+
+// Not this
+const string bad = *myOptional;
+```

--- a/cpp.md
+++ b/cpp.md
@@ -229,16 +229,39 @@ auto name = result[0]["name"];
 auto value = result[0]["value"];
 ```
 
-## Handling optionals
+## Unpacking optionals
 
 When unpacking an optional value, you should use the `.value()` method or `.value_or()` rather than directly dereferencing with `*`
 
 ```cpp
 const optional<string> myOptional = optional{"Hello world!"};
 
-// Do this
+// Good
 const string good = myOptional.value();
 
-// Not this
+// Bad
 const string bad = *myOptional;
+```
+
+## Prefer early returns
+
+Just like in E/App, we should prefer early returns when it's feasible to do so:
+
+```cpp
+void myGoodFunc(const string& myStr)
+{
+    // good, early return
+    if (myStr.empty()) {
+        return;
+    }
+    doSomething(myStr);
+}
+
+void myBadFunc(const string& myStr)
+{
+    // bad, effects nested in conditional
+    if (!myStr.empty()) {
+        doSomething(myStr);
+    }
+}
 ```

--- a/cpp.md
+++ b/cpp.md
@@ -270,20 +270,20 @@ ASSERT_FALSE(myOptional.has_value());
 Just like in E/App, we should prefer early returns when it's feasible to do so:
 
 ```cpp
-void myGoodFunc(const string& myStr)
+void myGoodFunction(const string& name)
 {
-    // good, early return
-    if (myStr.empty()) {
+    // Good, early return
+    if (name.empty()) {
         return;
     }
-    doSomething(myStr);
+    doSomething(name);
 }
 
-void myBadFunc(const string& myStr)
+void myBadFunction(const string& name)
 {
-    // bad, effects nested in conditional
+    // Bad, nested functionality
     if (!myStr.empty()) {
-        doSomething(myStr);
+        doSomething(name);
     }
 }
 ```

--- a/cpp.md
+++ b/cpp.md
@@ -243,6 +243,28 @@ const string good = myOptional.value();
 const string bad = *myOptional;
 ```
 
+When making assertions about whether or not an optional has a value, use `.has_value()` rather than relying on its implicit truthiness.
+
+```cpp
+const optional<string> myOptional = optional{"Hello world!"};
+
+// Bad - implicit conversion of optional to boolean
+if (myOptional) {
+    doSomething();
+}
+
+// Good - clear unpacking of optional
+if (myOptional.has_value()) {
+    doSomething();
+}
+
+// Bad - implicit conversion of optional to boolean
+ASSERT_FALSE(myOptional);
+
+// Good - clear unpacking of optional
+ASSERT_FALSE(myOptional.has_value());
+```
+
 ## Prefer early returns
 
 Just like in E/App, we should prefer early returns when it's feasible to do so:

--- a/cpp.md
+++ b/cpp.md
@@ -290,7 +290,9 @@ void myBadFunction(const string& name)
 
 ## Using assertions in tests
 
-You should prefer using `ASSERT_` over `EXPECT_` in tests, unless you have a specific reason to do otherwise. The reason for this is because `ASSERT_` will fail the test with the first failed assertion, while `EXPECT_` will fail the test and keep going, making the root cause of the failure less clear.
+You should prefer using `EXPECT_` over `ASSERT_` in tests, given that when `EXPECT_` assertion fails the execution of the test doesn't stop. This is useful when working on tests because you don't have to get one working in order to get the next one to run. Moreover, when assertions fail using `EXPECT_` they output shows the assertion that failed with its line number.
+
+You should use `ASSERT_` for assertions that need to pass before the next assertions in the test are run. Said differently, if one assertion depends on another one succeeding, you should use `ASSERT_` on the first one because there's no point in continuing to run the test if the `ASSERT_` fails
 
 ```cpp
 // GOOD

--- a/cpp.md
+++ b/cpp.md
@@ -287,3 +287,15 @@ void myBadFunc(const string& myStr)
     }
 }
 ```
+
+## Using assertions in tests
+
+You should prefer using `ASSERT_` over `EXPECT_` in tests, unless you have a specific reason to do otherwise. The reason for this is because `ASSERT_` will fail the test with the first failed assertion, while `EXPECT_` will fail the test and keep going, making the root cause of the failure less clear.
+
+```cpp
+// GOOD
+ASSERT_TRUE(true);
+
+// Bad
+EXPECT_TRUE(true);
+```


### PR DESCRIPTION
Coming from https://github.com/Expensify/Auth/pull/12206#discussion_r1757497805