### PR TITLE
Add full words guideline

### DIFF
--- a/general.md
+++ b/general.md
@@ -9,6 +9,7 @@ Language Agnostic Coding Standard
 
 ## Variables
 - Variables should always start lowercase and be camelCase (caveat see #Acryonyms)
+- Use of full words within names is RECOMMENDED; avoid abbreviations that create ambiguity (e.g. Bad: msg Good: message)
 
 ## Acronyms
 - Acronyms - should always be UPPERCASE unless it is the beginning of a variable name in which it should follow Variable


### PR DESCRIPTION
Coming from this conversation: https://expensify.slack.com/archives/C03TQ48KC/p1749768510369149

This bullet point was originally present in the style guide for `shell`, but I think this really applies to all our code base:

https://github.com/Expensify/Style-Guide/blob/main/shell.md#variable-names